### PR TITLE
chore: release adguard-home 1.0.0

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,3 +1,3 @@
 {
-  "charts/adguard-home": "0.1.0"
+  "charts/adguard-home": "1.0.0"
 }

--- a/charts/adguard-home/Chart.yaml
+++ b/charts/adguard-home/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: adguard-home
 description: A Helm chart for deploying AdGuard Home DNS server
 type: application
-version: 0.1.0
+version: 1.0.0
 appVersion: "v0.107.43"
 kubeVersion: ">=1.20.0"
 keywords:


### PR DESCRIPTION
🤖 I have created a release *beep* *boop*

## 1.0.0 (2024-01-01)

### Features

* Complete initial AdGuard Home Helm chart development ([58e358a](https://github.com/NitriKx/adguard-home-helm/commit/58e358a))
* Includes all major features: persistence, health checks, custom config
* Full CI/CD pipeline with automated testing and releases
* Renovate configuration for automated dependency updates
* Production-ready with enterprise-grade features

This PR was generated with [Release Please](https://github.com/google-github-actions/release-please).